### PR TITLE
Mongodump timeout directive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,6 +199,7 @@ The following is an example of what a configuration file looks like:
     output_dir: "/opt/tmp/mydir"
   mongodb:
     mongodump: "/opt/bin/mongodump"
+    mongodump_timeout: 600
     host_defaults:
       port: 666
       user_name: "satan"
@@ -253,6 +254,7 @@ to connect to, including databases that are going to be backed up through *mongo
 
     mongodb:
         mongodump: "/opt/bin/mongodump"
+        mongodump_timeout: 600
         host_defaults:
             user_name: tom
             address: db.example.local
@@ -291,6 +293,14 @@ Directives
 -  Type: **string**
 -  Default value : ``mongodump``
 -  Role: full path to the ``mongodump`` executable used by m2bk
+
+``mongodb.mongodump_timeout``
+"""""""""""""""""""""
+
+-  Type: **integer**
+-  Required: NO
+-  Default value : ``600``
+-  Role: Max execution time of the ``mongodump`` executable used by m2bk
 
 ``mongodb.host_defaults`` section
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/data/m2bk.yaml
+++ b/data/m2bk.yaml
@@ -25,6 +25,10 @@ mongodb:
 #  Default value: mongodump
 #  mongodump: "/usr/bin/mongodump"
 
+#  Max execution time of the mongodump executable used by m2bk
+#  Default value: 600
+#  mongodump_timeout: 600
+
 #  Directory where m2bk is going to temporarily save backup files
 #  Default value: /tmp/m2bk
 


### PR DESCRIPTION
First off, thanks for this tool. It's really useful and exactly what I was after for a simple way to take MongoDB backups and store in S3.

I've just run into a timeout issue with one of our larger MongoDB Collections whereby the dump was exceeding the 600s timeout hardcoded.

I've now added the timeout as a directive that can be configured in the m2bk.yml file. I initially coded it so it could be set per host definition however felt it probably wasn't the best place and would be much better as a global option along side the mongodump path directive. 

I'm actually a PHP developer and this is the first foray into Python code so any advice and/or recommendations are greatly appreciated =)